### PR TITLE
Preserve "this" in returned function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,9 +151,10 @@ S3Store.prototype.serve = function(options) {
         };
     }
 
+    var that = this;
     return function (req, res, next) {
         var params = {
-            Bucket: this.config.bucket,
+            Bucket: that.config.bucket,
             Key: req.path.replace(/^\//, '')
         };
 


### PR DESCRIPTION
I get this error running against ghost 0.11.2

`
 TypeError: Cannot read property 'config' of undefined
    at node_modules/ghost-s3-storage-adapter/index.js:157:25
`

Investigating the stack trace lead me to this fix, which resolved the problem.
